### PR TITLE
增加 timeout 选项和相应的 renew, cleanup, keys 接口

### DIFF
--- a/lib/backend/LevelDB.js
+++ b/lib/backend/LevelDB.js
@@ -6,5 +6,8 @@ module.exports = {
     },
     set: (conn, opts, k, v) => conn.set(k, v),
     has: (conn, opts, k) => conn.has(k),
-    remove: (conn, opts, k) => conn.remove(k)
+    keys: (conn, opts) => {},
+    renew: (conn, opts) => {},
+    remove: (conn, opts, k) => conn.remove(k),
+    cleanup: (conn, opts) => {},
 };

--- a/lib/backend/Map.js
+++ b/lib/backend/Map.js
@@ -3,5 +3,8 @@ module.exports = {
     get: (conn, opts, k) => conn.get(k),
     set: (conn, opts, k, v) => conn.set(k, v),
     has: (conn, opts, k) => conn.has(k),
-    remove: (conn, opts, k) => conn.remove(k)
+    keys: (conn, opts) => Object.keys(conn.toJSON()),
+    renew: (conn, opts, k) => conn.set(k, conn.get(k)),
+    remove: (conn, opts, k) => conn.remove(k),
+    cleanup: (conn, opts) => {},
 };

--- a/lib/backend/MongoDB.js
+++ b/lib/backend/MongoDB.js
@@ -9,16 +9,37 @@ function _q(opts, k) {
 function _d(opts, v) {
     var doc = {};
     doc[utils.value_name(opts)] = v;
+    if (utils.timeout(opts) > 0) doc._timestamp = new Date();
     return doc;
 }
 
 module.exports = {
-    setup: (conn, opts) => {},
+    setup: (conn, opts) => {
+        if (!(utils.timeout(opts) > 0)) return;
+        conn.runCommand({
+            createIndexes: utils.table_name(opts),
+            indexes: [{
+                key: {
+                    _timestamp: 1
+                },
+                name: '_timestamp_',
+                expireAfterSeconds: utils.timeout(opts)/1000
+            }]
+        });
+    },
     get: (conn, opts, k) => {
         var r = conn.getCollection(utils.table_name(opts)).findOne(_q(opts, k), _d(opts, 1));
         return r == null ? null : r[utils.value_name(opts)]
     },
     set: (conn, opts, k, v) => conn.getCollection(utils.table_name(opts)).update(_q(opts, k), { $set: _d(opts, v) }, true),
     has: (conn, opts, k) => conn.getCollection(utils.table_name(opts)).find(_q(opts, k)).hasNext(),
+    keys: (conn, opts, k) => conn.getCollection(utils.table_name(opts)).find(_q(opts, k)).toArray().reduce((a, b) => a.concat(b[utils.key_name(opts)]), []),
+    renew: (conn, opts, k) => {
+        if (!(utils.timeout(opts) > 0)) return;
+        var mass = conn.getCollection(utils.table_name(opts));
+        var r = mass.findOne(_q(opts, k), _d(opts, 1));
+        return r === null ? false : mass.update(_q(opts, k), { $set: _d(opts, r[utils.value_name(opts)]) });
+    },
     remove: (conn, opts, k) => conn.getCollection(utils.table_name(opts)).remove(_q(opts, k)),
+    cleanup: (conn, opts, k) => {},
 };

--- a/lib/backend/Object.js
+++ b/lib/backend/Object.js
@@ -6,5 +6,8 @@ module.exports = {
     },
     set: (conn, opts, k, v) => conn[k] = v,
     has: (conn, opts, k) => conn.hasOwnProperty(k),
-    remove: (conn, opts, k) => delete conn[k]
+    keys: (conn, opts) => {},
+    renew: (conn, opts) => {},
+    remove: (conn, opts, k) => delete conn[k],
+    cleanup: (conn, opts) => {},
 };

--- a/lib/backend/Redis.js
+++ b/lib/backend/Redis.js
@@ -2,7 +2,7 @@ var utils = require('../utils');
 
 function getTable(conn, opts) {
     var name = utils.table_name(opts);
-    return name ? conn.getHash(name) : conn;
+    return !name || name === 'kvs' ? conn : conn.getHash(name);
 }
 
 module.exports = {
@@ -11,7 +11,17 @@ module.exports = {
         var v = getTable(conn, opts).get(k);
         return v === null ? null : v.toString();
     },
-    set: (conn, opts, k, v) => getTable(conn, opts).set(k, v),
+    set: (conn, opts, k, v) => {
+        var name = utils.table_name(opts);
+        return !name || name === 'kvs' ? conn.set(k, v, utils.timeout(opts)) : conn.getHash(name).set(k, v);
+    },
     has: (conn, opts, k) => getTable(conn, opts).exists(k),
-    remove: (conn, opts, k) => getTable(conn, opts).del(k)
+    keys: (conn, opts, k) => getTable(conn, opts).keys('*'),
+    renew: (conn, opts, k) => {
+        if (!(utils.timeout(opts) > 0)) return;
+        var name = utils.table_name(opts);
+        return !name || name === 'kvs' ? conn.expire(k, utils.timeout(opts)) : undefined;
+    },
+    remove: (conn, opts, k) => getTable(conn, opts).del(k),
+    cleanup: (conn, opts, k) => {},
 };

--- a/lib/backend/sql.js
+++ b/lib/backend/sql.js
@@ -1,17 +1,39 @@
 var utils = require('../utils');
 
+function _v(opts, value) {
+    return utils.timeout(opts) > 0 ? value : '';
+}
+
+function exec(conn, sql, arg0, arg1, arg2) {
+    var params = [sql];
+    do {
+        if (arg0 === undefined) break;
+        params.push(arg0);
+        if (arg1 === undefined) break;
+        params.push(arg1);
+        if (arg2 === undefined) break;
+        params.push(arg2);
+    } while (false);
+
+    return conn.execute.apply(conn, params);
+}
+
 function sql(opts, method) {
     var sqls = opts.sqls;
 
     if (!sqls)
         sqls = opts.sqls = {
             get: 'SELECT ' + utils.value_name(opts) + ' FROM ' + utils.table_name(opts) +
-                ' WHERE ' + utils.key_name(opts) + ' = ?;',
-            set: 'REPLACE INTO ' + utils.table_name(opts) + ' VALUES(?,?);',
+                ' WHERE ' + utils.key_name(opts) + ' = ?' + _v(opts, ' and timestamp >= ?') + ';',
+            set: 'REPLACE INTO ' + utils.table_name(opts) + ' VALUES(?,?' + _v(opts, ',?') + ');',
             has: 'SELECT 1 FROM ' + utils.table_name(opts) + ' WHERE ' +
+                utils.key_name(opts) + ' = ?' + _v(opts, ' and timestamp >= ?') + ';',
+            keys: 'SELECT ' + utils.key_name(opts) + ' FROM ' + utils.table_name(opts) + ';',
+            renew: 'UPDATE ' + utils.table_name(opts) + ' SET timestamp = ? WHERE ' +
                 utils.key_name(opts) + ' = ?;',
             remove: 'DELETE FROM ' + utils.table_name(opts) + ' WHERE ' +
                 utils.key_name(opts) + ' = ?;',
+            cleanup: 'DELETE FROM ' + utils.table_name(opts) + ' WHERE timestamp < ?;',
         }
 
     return sqls[method];
@@ -21,15 +43,23 @@ module.exports = {
     setup: (conn, opts) => {
         var sql = 'CREATE TABLE IF NOT EXISTS ' + utils.table_name(opts) + '(' +
             utils.key_name(opts) + ' VARCHAR(' + utils.key_size(opts) + ') PRIMARY KEY, ' +
-            utils.value_name(opts) + ' VARCHAR(' + utils.value_size(opts) + '));';
+            utils.value_name(opts) + ' VARCHAR(' + utils.value_size(opts) + ')' +
+            _v(opts, ', timestamp BIGINT') + ');';
 
         conn.execute(sql);
     },
     get: (conn, opts, k) => {
-        var rs = conn.execute(sql(opts, 'get'), k);
+        var rs = exec(conn, sql(opts, 'get'), k,
+                      utils.timeout(opts) > 0 ? new Date().getTime() - utils.timeout(opts) : undefined);
         return rs.length ? rs[0][0] : null;
     },
-    set: (conn, opts, k, v) => conn.execute(sql(opts, 'set'), k, v),
-    has: (conn, opts, k) => conn.execute(sql(opts, 'has'), k).length > 0,
-    remove: (conn, opts, k) => conn.execute(sql(opts, 'remove'), k)
+    set: (conn, opts, k, v) => exec(conn, sql(opts, 'set'), k, v,
+                                    utils.timeout(opts) > 0 ? new Date().getTime() : undefined),
+    has: (conn, opts, k) => exec(conn, sql(opts, 'has'), k,
+                                 utils.timeout(opts) > 0 ? new Date().getTime() - utils.timeout(opts) : undefined).length > 0,
+    keys: (conn, opts) => conn.execute(sql(opts, 'keys')).reduce((a, b) => a.concat(b[0]), []),
+    renew: (conn, opts, k) => utils.timeout(opts) > 0 ?
+        conn.execute(sql(opts, 'renew'), new Date().getTime(), k) : undefined,
+    remove: (conn, opts, k) => conn.execute(sql(opts, 'remove'), k),
+    cleanup: (conn, opts) => conn.execute(sql(opts, 'cleanup'), new Date().getTime() - utils.timeout(opts)),
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,22 +15,20 @@ var backends = {
 function backend(conn) {
     var t = Object.prototype.toString.call(conn);
     var _back = backends[t.substr(8, t.length - 9)];
-    if (!_back) {
-        _back = conn._back;
-        if (!_back)
-            _back = conn;
-    }
-
-    return _back;
+    return _back || conn._back || conn;
 }
 
 function kv(conn, opts) {
     opts = opts || {};
 
     var cache;
-    if (opts.cache)
+    if (opts.cache) {
         cache = new util.LruCache(utils.cache_size(opts),
             utils.cache_timeout(opts));
+        cache.keys = () => Object.keys(conn.toJSON());
+        cache.renew = k => cache.set(k, cache.get(k));
+        cache.cleanup = () => {};
+    }
 
     if (typeof conn === 'function') {
         util.extend(this, {
@@ -51,12 +49,20 @@ function kv(conn, opts) {
                 return cache ? (cache.has(k) || backend(c).has(c, opts, k)) :
                     backend(c).has(c, opts, k);
             }),
+            keys: () => conn(utils.pool_name(opts), c => backend(c).keys(c, opts)),
+            renew: k => conn(utils.pool_name(opts), c => {
+                k = utils.prefix_key(k, opts);
+                if (cache)
+                    cache.renew(k);
+                backend(c).renew(c, opts, k);
+            }),
             remove: k => conn(utils.pool_name(opts), c => {
                 k = utils.prefix_key(k, opts);
                 if (cache)
                     cache.remove(k);
                 backend(c).remove(c, opts, k);
             }),
+            cleanup: () => conn(utils.pool_name(opts), c => backend(c).cleanup(c, opts)),
             cache_has: k => cache && cache.has(utils.prefix_key(k, opts)),
             cache_clear: () => cache && cache.clear()
         });
@@ -81,12 +87,20 @@ function kv(conn, opts) {
                 k = utils.prefix_key(k, opts);
                 return cache ? (cache.has(k) || _back.has(conn, opts, k)) : _back.has(conn, opts, k);
             },
+            keys: () => _back.keys(conn, opts),
+            renew: k => {
+                k = utils.prefix_key(k, opts);
+                if (cache)
+                    cache.renew(k);
+                _back.renew(conn, opts, k);
+            },
             remove: k => {
                 k = utils.prefix_key(k, opts);
                 if (cache)
                     cache.remove(k);
                 _back.remove(conn, opts, k);
             },
+            cleanup: () => _back.cleanup(conn, opts),
             cache_has: k => cache && cache.has(utils.prefix_key(k, opts)),
             cache_clear: () => cache && cache.clear()
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,6 +30,10 @@ exports.cache_timeout = function(opts) {
     return opts.cache_timeout !== undefined ? opts.cache_timeout : 60 * 1000;
 }
 
+exports.timeout = function(opts) {
+    return opts.timeout !== undefined ? opts.timeout : 0;
+}
+
 exports.pool_name = function(opts) {
     return opts.pool_name !== undefined ? opts.pool_name : '';
 }

--- a/test.js
+++ b/test.js
@@ -10,6 +10,17 @@ var util = require('util');
 
 var pool = require('fib-pool');
 
+var coroutine = require('coroutine');
+var rc = require('process').run;
+var conf = {
+    user: 'chanjet',
+    password: 'd3j',
+    database: 'test',
+};
+
+// The TTL should be large enough to avoid delays of operations.
+var ms = 500; // 500 milliseconds
+
 describe("kv", () => {
     var conn;
 
@@ -57,6 +68,54 @@ describe("kv", () => {
         });
     }
 
+    function test_timeout(name, opts, _before, _after) {
+        describe(name, () => {
+            var kv_db;
+
+            before(_before);
+            after(_after);
+
+            it('setup', () => {
+                kv_db = new kv(conn, opts);
+                kv_db.setup();
+            });
+
+            it('timeout/renew', function() {
+                var ns = ms * 0.5 + 1;
+
+                kv_db.set('a', 'test a');
+                coroutine.sleep(ns);
+                assert.equal(kv_db.get('a'), 'test a');
+
+                kv_db.renew('a');
+                coroutine.sleep(ns);
+                assert.equal(kv_db.get('a'), 'test a');
+
+                coroutine.sleep(ns);
+                assert.equal(kv_db.get('a'), null);
+            });
+
+            it('cleanup/keys', function() {
+                var ns = ms * 0.5 + 1;
+
+                kv_db.set('a', 'test a');
+                coroutine.sleep(ns);
+                kv_db.set('b', 'test b');
+
+                kv_db.cleanup();
+                assert.equal(kv_db.keys().length, 2);
+
+                coroutine.sleep(ns);
+                kv_db.cleanup();
+                assert.equal(kv_db.keys().length, 1);
+
+                coroutine.sleep(ns);
+                kv_db.cleanup();
+                assert.equal(kv_db.keys().length, 0);
+            });
+        });
+    }
+
     test_kv('Object', {},
         () => conn = {},
         () => conn = {});
@@ -83,6 +142,10 @@ describe("kv", () => {
         () => conn = new util.LruCache(65536),
         () => conn = {});
 
+    test_timeout('LruCache timeout', {},
+        () => conn = new util.LruCache(65536, ms),
+        () => conn = {});
+
     test_kv('LevelDB', {},
         () => conn = db.openLevelDB("test.ldb"),
         () => conn.close());
@@ -106,7 +169,11 @@ describe("kv", () => {
 
     test_kv('SQLite', {},
         () => conn = db.openSQLite("test.db"),
-        () => conn.close());
+        () => {conn.close()
+           try {
+               fs.unlink("test.db");
+           } catch (e) {};
+        });
 
     test_kv('SQLite opts', {
             table_name: 'test', // default: kvs
@@ -116,6 +183,12 @@ describe("kv", () => {
             value_size: 256, // default: 256
             prefix: 'test_',
             cache: true
+        },
+        () => conn = db.openSQLite("test.db"),
+        () => conn.close());
+
+    test_timeout('SQLite timeout', {
+            timeout: ms
         },
         () => conn = db.openSQLite("test.db"),
         () => {
@@ -128,7 +201,7 @@ describe("kv", () => {
 
     if (process.argv.indexOf('full') >= 0) {
         test_kv('MySQL', {},
-            () => conn = db.openMySQL("mysql://root@localhost/test"),
+            () => conn = db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database),
             () => {
                 try {
                     conn.execute('DROP TABLE kvs;');
@@ -145,7 +218,7 @@ describe("kv", () => {
                 prefix: 'test_',
                 cache: true
             },
-            () => conn = db.openMySQL("mysql://root@localhost/test"),
+            () => conn = db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database),
             () => {
                 try {
                     conn.execute('DROP TABLE test;');
@@ -153,17 +226,76 @@ describe("kv", () => {
                 conn.close();
             });
 
+        test_timeout('MySQL timeout', {
+                timeout: ms
+            },
+            () => conn = db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database),
+            () => {
+                try {
+                    conn.execute('DROP TABLE kvs;');
+                } catch (e) {};
+                conn.close();
+            });
+
         test_kv('MySQL pool', {},
-            () => conn = pool(() => db.openMySQL("mysql://root@localhost/test")),
+            () => conn = pool(() => db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database)),
             () => {
                 try {
                     conn(c => c.execute('DROP TABLE kvs;'));
                 } catch (e) {};
             });
 
+        test_timeout('MySQL pool timeout', {
+                timeout: ms
+            },
+            () => conn = pool(() => db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database)),
+            () => {
+                try {
+                    conn(c => c.execute('DROP TABLE kvs;'));
+                } catch (e) {};
+            });
+
+        test_kv('Redis', {},
+            () => conn = db.openRedis("redis://127.0.0.1"),
+            () => {
+                try {
+                    conn.del('kvs');
+                } catch (e) {};
+                conn.close();
+            });
+
+        test_kv('Redis opts', {
+                table_name: 'test', // default: kvs
+                prefix: 'test_',
+                cache: true
+            },
+            () => conn = db.openRedis("redis://127.0.0.1"),
+            () => {
+                try {
+                    conn.del('test');
+                } catch (e) {};
+                conn.close();
+            });
+
+        test_timeout('Redis timeout', {
+                timeout: ms
+            },
+            () => conn = db.openRedis("redis://127.0.0.1"),
+            () => {
+                try {
+                    //conn.del('kvs');
+                } catch (e) {};
+                conn.close();
+            });
+
         test_kv('MongoDB', {},
             () => conn = db.openMongoDB("mongodb://127.0.0.1/test"),
-            () => conn.close());
+            () => {
+                try {
+                    conn.getCollection('kvs').drop();
+                } catch (e) {};
+                conn.close();
+            });
 
         test_kv('MongoDB opts', {
                 table_name: 'test', // default: kvs
@@ -180,22 +312,67 @@ describe("kv", () => {
                 conn.close();
             });
 
-        test_kv('Redis', {},
-            () => conn = db.openRedis("redis://127.0.0.1"),
-            () => conn.close());
+        describe('MongoDB timeout', () => {
+            var kv_db;
+            var ms = 30000; // ms should be great than 2000 here
 
-        test_kv('Redis opts', {
-                table_name: '', // default: kvs
-                prefix: 'test_',
-                cache: true
-            },
-            () => conn = db.openRedis("redis://127.0.0.1"),
-            () => {
+            before(() => conn = db.openMongoDB("mongodb://127.0.0.1/test"));
+            after(() => {
                 try {
-                    conn.del('test');
+                    conn.getCollection('kvs').drop();
                 } catch (e) {};
                 conn.close();
             });
+
+            it('setup', () => {
+                var opts = { timeout: ms };
+                kv_db = new kv(conn, opts);
+                kv_db.setup();
+            });
+
+            it('timeout/renew/keys/cleanup', function() {
+
+                kv_db.set('a', 'test a');
+                coroutine.sleep(1000);
+                kv_db.set('b', 'test b');
+
+                kv_db.cleanup();
+                assert.equal(kv_db.keys().length, 2);
+
+                var timer = ms + 60000;
+                while (timer -= 1000) {
+                    rc('echo', ['-ne', '\r', timer/1000, 'seconds left to timeout (1/3)    ']);
+                    coroutine.sleep(1000);
+                    if (!kv_db.get('a'))
+                        break;
+                    kv_db.renew('b');
+                }
+                rc('echo', ['-e', '\r', timer/1000, 'seconds left to timeout (1/3)    ']);
+
+                kv_db.cleanup();
+                assert.equal(kv_db.keys().length, 1);
+
+                timer = ms;
+                while (timer -= 1000) {
+                    rc('echo', ['-ne', '\r', timer/1000, 'seconds left to timeout (2/3)    ']);
+                    coroutine.sleep(1000);
+                }
+                rc('echo', ['-e', '\r', timer/1000, 'seconds left to timeout (2/3)    ']);
+                assert.equal(kv_db.get('b'), 'test b');
+
+                timer = 60000;
+                while (timer -= 1000) {
+                    rc('echo', ['-ne', '\r', timer/1000, 'seconds left to timeout (3/3)    ']);
+                    coroutine.sleep(1000);
+                }
+                rc('echo', ['-e', '\r', timer/1000, 'seconds left to timeout (3/3)    ']);
+                assert.equal(kv_db.get('b'), null);
+                kv_db.cleanup();
+                assert.equal(kv_db.keys().length, 0);
+            });
+
+        });
+
     }
 });
 


### PR DESCRIPTION
代码实现时的选择:

1. Redis: 在没有 table_name 或 table_name 为 'kvs' 时, 不使用 hash 对象, 以使用 expire 功能
2. SQLite, MySQL: keys() 结果在key过期后不自动更新, 在 cleanup() 后才会移除过期的key
3. 考虑兼容性, 没有使用 ES6 剩余参数语法, 也没有使用 arguments