### PR TITLE
增加 timeout 选项和相应的 renew, keys 接口

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,17 +21,21 @@ conn: database connection or connection factory like fib-pool
 opts: kvs options
 ```
 
-opts | default | object/Map | LruCache | LevelDB | Redis | MongoDB |  SQLite/MySQL
----  |   ---   | --- |   ----   |   ---   |  ---  |   ---   | ---
-table_name | "kvs" | x | x | x | √ | √ | √ 
-key_name | "k" | x | x | x | x | √ | √ 
-value_name | "v" | x | x | x | x | √ | √ 
-key_size | 32 | x | x | x | x | x | √ 
-value_size | 256 | x | x | x | x | x | √ 
-prefix | "" | √ | √ | √ | √ | √ | √ 
-cache | false | √ | √ | √ | √ | √ | √ 
-cache_size | 65536 | √ | √ | √ | √ | √ | √ 
-cache_timeout(ms) | 60000 | √ | √ | √ | √ | √ | √ 
+| opts                 | default | object/Map | LruCache | LevelDB | Redis | MongoDB | SQLite/MySQL |
+|----------------------|---------|------------|----------|---------|-------|---------|--------------|
+| table_name           |   "kvs" | x          | x        | x       | √     | √       | √            |
+| key_name             |     "k" | x          | x        | x       | x     | √       | √            |
+| value_name           |     "v" | x          | x        | x       | x     | √       | √            |
+| key_size             |      32 | x          | x        | x       | x     | x       | √            |
+| value_size           |     256 | x          | x        | x       | x     | x       | √            |
+| cleanup_interval(ms) |   60000 | x          | x        | x       | x     | x       | √            |
+| timeout(ms)          |       0 | x          | √        | x       | √     | √       | √            |
+| prefix               |      "" | √          | √        | √       | √     | √       | √            |
+| cache                |   false | √          | √        | √       | √     | √       | √            |
+| cache_size           |   65536 | √          | √        | √       | √     | √       | √            |
+| cache_timeout(ms)    |   60000 | √          | √        | √       | √     | √       | √            |
+
+A key will not expire if `timeout` is less than or equal to 0.
 
 Simple example (memory backend).
 ```JavaScript
@@ -74,6 +78,12 @@ stores a key-value pair.
 
 ### e = kvs.has(k)
 returns whether a key is set on the store.
+
+### e = kvs.keys()
+returns all keys in the store.
+
+### e = kvs.renew(k)
+renews TTL for an unexpired key.
 
 ### kvs.remove(k)
 deletes a key-value pair by key.

--- a/lib/backend/LevelDB.js
+++ b/lib/backend/LevelDB.js
@@ -6,5 +6,7 @@ module.exports = {
     },
     set: (conn, opts, k, v) => conn.set(k, v),
     has: (conn, opts, k) => conn.has(k),
-    remove: (conn, opts, k) => conn.remove(k)
+    keys: (conn, opts) => {},
+    renew: (conn, opts) => {},
+    remove: (conn, opts, k) => conn.remove(k),
 };

--- a/lib/backend/Map.js
+++ b/lib/backend/Map.js
@@ -3,5 +3,7 @@ module.exports = {
     get: (conn, opts, k) => conn.get(k),
     set: (conn, opts, k, v) => conn.set(k, v),
     has: (conn, opts, k) => conn.has(k),
-    remove: (conn, opts, k) => conn.remove(k)
+    keys: (conn, opts) => Object.keys(conn.toJSON()),
+    renew: (conn, opts, k) => conn.set(k, conn.get(k)),
+    remove: (conn, opts, k) => conn.remove(k),
 };

--- a/lib/backend/MongoDB.js
+++ b/lib/backend/MongoDB.js
@@ -9,16 +9,36 @@ function _q(opts, k) {
 function _d(opts, v) {
     var doc = {};
     doc[utils.value_name(opts)] = v;
+    if (utils.timeout(opts) > 0) doc._timestamp = new Date();
     return doc;
 }
 
 module.exports = {
-    setup: (conn, opts) => {},
+    setup: (conn, opts) => {
+        if (!(utils.timeout(opts) > 0)) return;
+        conn.runCommand({
+            createIndexes: utils.table_name(opts),
+            indexes: [{
+                key: {
+                    _timestamp: 1
+                },
+                name: '_timestamp_',
+                expireAfterSeconds: utils.timeout(opts)/1000
+            }]
+        });
+    },
     get: (conn, opts, k) => {
         var r = conn.getCollection(utils.table_name(opts)).findOne(_q(opts, k), _d(opts, 1));
         return r == null ? null : r[utils.value_name(opts)]
     },
     set: (conn, opts, k, v) => conn.getCollection(utils.table_name(opts)).update(_q(opts, k), { $set: _d(opts, v) }, true),
     has: (conn, opts, k) => conn.getCollection(utils.table_name(opts)).find(_q(opts, k)).hasNext(),
+    keys: (conn, opts, k) => conn.getCollection(utils.table_name(opts)).find(_q(opts, k)).toArray().reduce((a, b) => a.concat(b[utils.key_name(opts)]), []),
+    renew: (conn, opts, k) => {
+        if (!(utils.timeout(opts) > 0)) return;
+        var mass = conn.getCollection(utils.table_name(opts));
+        var r = mass.findOne(_q(opts, k), _d(opts, 1));
+        return r === null ? false : mass.update(_q(opts, k), { $set: _d(opts, r[utils.value_name(opts)]) });
+    },
     remove: (conn, opts, k) => conn.getCollection(utils.table_name(opts)).remove(_q(opts, k)),
 };

--- a/lib/backend/Object.js
+++ b/lib/backend/Object.js
@@ -6,5 +6,7 @@ module.exports = {
     },
     set: (conn, opts, k, v) => conn[k] = v,
     has: (conn, opts, k) => conn.hasOwnProperty(k),
-    remove: (conn, opts, k) => delete conn[k]
+    keys: (conn, opts) => {},
+    renew: (conn, opts) => {},
+    remove: (conn, opts, k) => delete conn[k],
 };

--- a/lib/backend/Redis.js
+++ b/lib/backend/Redis.js
@@ -6,12 +6,19 @@ function getTable(conn, opts) {
 }
 
 module.exports = {
-    setup: (conn, opts) => {},
+    setup: (conn, opts) => {
+        if (utils.table_name(opts) && utils.timeout(opts) > 0) {
+            conn.close();
+            throw new Error('table_name must be "" to set timeout (TTL) for Redis');
+        }
+    },
     get: (conn, opts, k) => {
         var v = getTable(conn, opts).get(k);
         return v === null ? null : v.toString();
     },
-    set: (conn, opts, k, v) => getTable(conn, opts).set(k, v),
+    set: (conn, opts, k, v) => utils.timeout(opts) > 0 ? conn.set(k, v, utils.timeout(opts)) : getTable(conn, opts).set(k, v),
     has: (conn, opts, k) => getTable(conn, opts).exists(k),
-    remove: (conn, opts, k) => getTable(conn, opts).del(k)
+    keys: (conn, opts, k) => getTable(conn, opts).keys('*'),
+    renew: (conn, opts, k) => utils.timeout(opts) > 0 ? conn.expire(k, utils.timeout(opts)) : undefined,
+    remove: (conn, opts, k) => getTable(conn, opts).del(k),
 };

--- a/lib/backend/sql.js
+++ b/lib/backend/sql.js
@@ -1,17 +1,40 @@
 var utils = require('../utils');
 
+function _v(opts, value) {
+    return utils.timeout(opts) > 0 ? value : '';
+}
+
+function exec(conn, sql, arg0, arg1, arg2) {
+    var params = [sql];
+    do {
+        if (arg0 === undefined) break;
+        params.push(arg0);
+        if (arg1 === undefined) break;
+        params.push(arg1);
+        if (arg2 === undefined) break;
+        params.push(arg2);
+    } while (false);
+
+    return conn.execute.apply(conn, params);
+}
+
 function sql(opts, method) {
     var sqls = opts.sqls;
 
     if (!sqls)
         sqls = opts.sqls = {
             get: 'SELECT ' + utils.value_name(opts) + ' FROM ' + utils.table_name(opts) +
-                ' WHERE ' + utils.key_name(opts) + ' = ?;',
-            set: 'REPLACE INTO ' + utils.table_name(opts) + ' VALUES(?,?);',
+                ' WHERE ' + utils.key_name(opts) + ' = ?' + _v(opts, ' and _timestamp >= ?') + ';',
+            set: 'REPLACE INTO ' + utils.table_name(opts) + ' VALUES(?,?' + _v(opts, ',?') + ');',
             has: 'SELECT 1 FROM ' + utils.table_name(opts) + ' WHERE ' +
+                utils.key_name(opts) + ' = ?' + _v(opts, ' and _timestamp >= ?') + ';',
+            keys: 'SELECT ' + utils.key_name(opts) + ' FROM ' + utils.table_name(opts) +
+                _v(opts, ' WHERE _timestamp >= ?') + ';',
+            renew: 'UPDATE ' + utils.table_name(opts) + ' SET _timestamp = ? WHERE ' +
                 utils.key_name(opts) + ' = ?;',
             remove: 'DELETE FROM ' + utils.table_name(opts) + ' WHERE ' +
                 utils.key_name(opts) + ' = ?;',
+            cleanup: 'DELETE FROM ' + utils.table_name(opts) + ' WHERE _timestamp < ?;',
         }
 
     return sqls[method];
@@ -19,17 +42,36 @@ function sql(opts, method) {
 
 module.exports = {
     setup: (conn, opts) => {
-        var sql = 'CREATE TABLE IF NOT EXISTS ' + utils.table_name(opts) + '(' +
+        var _sql = 'CREATE TABLE IF NOT EXISTS ' + utils.table_name(opts) + '(' +
             utils.key_name(opts) + ' VARCHAR(' + utils.key_size(opts) + ') PRIMARY KEY, ' +
-            utils.value_name(opts) + ' VARCHAR(' + utils.value_size(opts) + '));';
+            utils.value_name(opts) + ' VARCHAR(' + utils.value_size(opts) + ')' +
+            _v(opts, ', _timestamp BIGINT') + ');';
 
-        conn.execute(sql);
+        conn.execute(_sql);
+
+        if (utils.timeout(opts) > 0) {
+            var _mark = setInterval(()=>{
+                try {
+                    conn.execute(sql(opts, 'cleanup'), new Date().getTime() - utils.timeout(opts));
+                } catch(e) {
+                    // 'Error: Invalid procedure call' arises when the connection is closed
+                    clearInterval(_mark);
+                }
+            }, utils.cleanup_interval(opts));
+        }
     },
     get: (conn, opts, k) => {
-        var rs = conn.execute(sql(opts, 'get'), k);
+        var rs = exec(conn, sql(opts, 'get'), k,
+                      utils.timeout(opts) > 0 ? new Date().getTime() - utils.timeout(opts) : undefined);
         return rs.length ? rs[0][0] : null;
     },
-    set: (conn, opts, k, v) => conn.execute(sql(opts, 'set'), k, v),
-    has: (conn, opts, k) => conn.execute(sql(opts, 'has'), k).length > 0,
-    remove: (conn, opts, k) => conn.execute(sql(opts, 'remove'), k)
+    set: (conn, opts, k, v) => exec(conn, sql(opts, 'set'), k, v,
+                                    utils.timeout(opts) > 0 ? new Date().getTime() : undefined),
+    has: (conn, opts, k) => exec(conn, sql(opts, 'has'), k,
+                                 utils.timeout(opts) > 0 ? new Date().getTime() - utils.timeout(opts) : undefined).length > 0,
+    keys: (conn, opts) => exec(conn, sql(opts, 'keys'),
+                              utils.timeout(opts) > 0 ? new Date().getTime() - utils.timeout(opts) : undefined).reduce((a, b) => a.concat(b[0]), []),
+    renew: (conn, opts, k) => utils.timeout(opts) > 0 ?
+        conn.execute(sql(opts, 'renew'), new Date().getTime(), k) : undefined,
+    remove: (conn, opts, k) => conn.execute(sql(opts, 'remove'), k),
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,22 +15,19 @@ var backends = {
 function backend(conn) {
     var t = Object.prototype.toString.call(conn);
     var _back = backends[t.substr(8, t.length - 9)];
-    if (!_back) {
-        _back = conn._back;
-        if (!_back)
-            _back = conn;
-    }
-
-    return _back;
+    return _back || conn._back || conn;
 }
 
 function kv(conn, opts) {
     opts = opts || {};
 
     var cache;
-    if (opts.cache)
+    if (opts.cache) {
         cache = new util.LruCache(utils.cache_size(opts),
             utils.cache_timeout(opts));
+        cache.keys = () => Object.keys(cache.toJSON());
+        cache.renew = k => cache.set(k, cache.get(k));
+    }
 
     if (typeof conn === 'function') {
         util.extend(this, {
@@ -50,6 +47,13 @@ function kv(conn, opts) {
                 k = utils.prefix_key(k, opts);
                 return cache ? (cache.has(k) || backend(c).has(c, opts, k)) :
                     backend(c).has(c, opts, k);
+            }),
+            keys: () => conn(utils.pool_name(opts), c => backend(c).keys(c, opts)),
+            renew: k => conn(utils.pool_name(opts), c => {
+                k = utils.prefix_key(k, opts);
+                if (cache)
+                    cache.renew(k);
+                backend(c).renew(c, opts, k);
             }),
             remove: k => conn(utils.pool_name(opts), c => {
                 k = utils.prefix_key(k, opts);
@@ -80,6 +84,13 @@ function kv(conn, opts) {
             has: k => {
                 k = utils.prefix_key(k, opts);
                 return cache ? (cache.has(k) || _back.has(conn, opts, k)) : _back.has(conn, opts, k);
+            },
+            keys: () => _back.keys(conn, opts),
+            renew: k => {
+                k = utils.prefix_key(k, opts);
+                if (cache)
+                    cache.renew(k);
+                _back.renew(conn, opts, k);
             },
             remove: k => {
                 k = utils.prefix_key(k, opts);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,6 +30,14 @@ exports.cache_timeout = function(opts) {
     return opts.cache_timeout !== undefined ? opts.cache_timeout : 60 * 1000;
 }
 
+exports.timeout = function(opts) {
+    return opts.timeout !== undefined ? opts.timeout : 0;
+}
+
+exports.cleanup_interval = function(opts) {
+    return opts.cleanup_interval !== undefined ? opts.cleanup_interval : 60 * 1000;
+}
+
 exports.pool_name = function(opts) {
     return opts.pool_name !== undefined ? opts.pool_name : '';
 }

--- a/test.js
+++ b/test.js
@@ -10,6 +10,17 @@ var util = require('util');
 
 var pool = require('fib-pool');
 
+var coroutine = require('coroutine');
+var rc = require('process').run;
+var conf = {
+    user: 'username',
+    password: 'password',
+    database: 'test',
+};
+
+// The TTL should be large enough considering delays of operations.
+var ms = 500; // 500 milliseconds
+
 describe("kv", () => {
     var conn;
 
@@ -57,6 +68,51 @@ describe("kv", () => {
         });
     }
 
+    function test_timeout(name, opts, _before, _after) {
+        describe(name, () => {
+            var kv_db;
+
+            before(_before);
+            after(_after);
+
+            it('setup', () => {
+                kv_db = new kv(conn, opts);
+                kv_db.setup();
+            });
+
+            it('timeout/renew', function() {
+                var ns = ms * 0.5 + 1;
+
+                kv_db.set('a', 'test a');
+                coroutine.sleep(ns);
+                assert.equal(kv_db.get('a'), 'test a');
+
+                kv_db.renew('a');
+                coroutine.sleep(ns);
+                assert.equal(kv_db.get('a'), 'test a');
+
+                coroutine.sleep(ns);
+                assert.equal(kv_db.get('a'), null);
+            });
+
+            it('keys', function() {
+                var ns = ms * 0.5 + 1;
+
+                kv_db.set('a', 'test a');
+                coroutine.sleep(ns);
+                kv_db.set('b', 'test b');
+
+                assert.equal(kv_db.keys().length, 2);
+
+                coroutine.sleep(ns);
+                assert.equal(kv_db.keys().length, 1);
+
+                coroutine.sleep(ns);
+                assert.equal(kv_db.keys().length, 0);
+            });
+        });
+    }
+
     test_kv('Object', {},
         () => conn = {},
         () => conn = {});
@@ -83,6 +139,10 @@ describe("kv", () => {
         () => conn = new util.LruCache(65536),
         () => conn = {});
 
+    test_timeout('LruCache timeout', {},
+        () => conn = new util.LruCache(65536, ms),
+        () => conn = {});
+
     test_kv('LevelDB', {},
         () => conn = db.openLevelDB("test.ldb"),
         () => conn.close());
@@ -106,7 +166,11 @@ describe("kv", () => {
 
     test_kv('SQLite', {},
         () => conn = db.openSQLite("test.db"),
-        () => conn.close());
+        () => {conn.close()
+           try {
+               fs.unlink("test.db");
+           } catch (e) {};
+        });
 
     test_kv('SQLite opts', {
             table_name: 'test', // default: kvs
@@ -116,6 +180,12 @@ describe("kv", () => {
             value_size: 256, // default: 256
             prefix: 'test_',
             cache: true
+        },
+        () => conn = db.openSQLite("test.db"),
+        () => conn.close());
+
+    test_timeout('SQLite timeout', {
+            timeout: ms
         },
         () => conn = db.openSQLite("test.db"),
         () => {
@@ -128,7 +198,7 @@ describe("kv", () => {
 
     if (process.argv.indexOf('full') >= 0) {
         test_kv('MySQL', {},
-            () => conn = db.openMySQL("mysql://root@localhost/test"),
+            () => conn = db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database),
             () => {
                 try {
                     conn.execute('DROP TABLE kvs;');
@@ -145,7 +215,7 @@ describe("kv", () => {
                 prefix: 'test_',
                 cache: true
             },
-            () => conn = db.openMySQL("mysql://root@localhost/test"),
+            () => conn = db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database),
             () => {
                 try {
                     conn.execute('DROP TABLE test;');
@@ -153,17 +223,72 @@ describe("kv", () => {
                 conn.close();
             });
 
+        test_timeout('MySQL timeout', {
+                timeout: ms
+            },
+            () => conn = db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database),
+            () => {
+                try {
+                    conn.execute('DROP TABLE kvs;');
+                } catch (e) {};
+                conn.close();
+            });
+
         test_kv('MySQL pool', {},
-            () => conn = pool(() => db.openMySQL("mysql://root@localhost/test")),
+            () => conn = pool(() => db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database)),
             () => {
                 try {
                     conn(c => c.execute('DROP TABLE kvs;'));
                 } catch (e) {};
             });
 
+        test_timeout('MySQL pool timeout', {
+                timeout: ms
+            },
+            () => conn = pool(() => db.openMySQL('mysql://' + conf.user + ':' + conf.password + '@localhost/' + conf.database)),
+            () => {
+                try {
+                    conn(c => c.execute('DROP TABLE kvs;'));
+                } catch (e) {};
+            });
+
+        test_kv('Redis', {},
+            () => conn = db.openRedis("redis://127.0.0.1"),
+            () => {
+                try {
+                    conn.del('kvs');
+                } catch (e) {};
+                conn.close();
+            });
+
+        test_kv('Redis opts', {
+                table_name: 'test', // default: kvs
+                prefix: 'test_',
+                cache: true
+            },
+            () => conn = db.openRedis("redis://127.0.0.1"),
+            () => {
+                try {
+                    conn.del('test');
+                } catch (e) {};
+                conn.close();
+            });
+
+        test_timeout('Redis timeout', {
+                table_name: '',
+                timeout: ms
+            },
+            () => conn = db.openRedis("redis://127.0.0.1"),
+            () => { conn.close(); });
+
         test_kv('MongoDB', {},
             () => conn = db.openMongoDB("mongodb://127.0.0.1/test"),
-            () => conn.close());
+            () => {
+                try {
+                    conn.getCollection('kvs').drop();
+                } catch (e) {};
+                conn.close();
+            });
 
         test_kv('MongoDB opts', {
                 table_name: 'test', // default: kvs
@@ -180,22 +305,64 @@ describe("kv", () => {
                 conn.close();
             });
 
-        test_kv('Redis', {},
-            () => conn = db.openRedis("redis://127.0.0.1"),
-            () => conn.close());
+        describe('MongoDB timeout', () => {
+            var kv_db;
+            var ms = 30000; // ms should be great than 2000 here
 
-        test_kv('Redis opts', {
-                table_name: '', // default: kvs
-                prefix: 'test_',
-                cache: true
-            },
-            () => conn = db.openRedis("redis://127.0.0.1"),
-            () => {
+            before(() => conn = db.openMongoDB("mongodb://127.0.0.1/test"));
+            after(() => {
                 try {
-                    conn.del('test');
+                    conn.getCollection('kvs').drop();
                 } catch (e) {};
                 conn.close();
             });
+
+            it('setup', () => {
+                var opts = { timeout: ms };
+                kv_db = new kv(conn, opts);
+                kv_db.setup();
+            });
+
+            it('timeout/renew/keys', function() {
+
+                kv_db.set('a', 'test a');
+                coroutine.sleep(1000);
+                kv_db.set('b', 'test b');
+
+                assert.equal(kv_db.keys().length, 2);
+
+                var timer = ms + 60000;
+                while (timer -= 1000) {
+                    rc('echo', ['-ne', '\r', timer/1000, 'seconds left to timeout (1/3)    ']);
+                    coroutine.sleep(1000);
+                    if (!kv_db.get('a'))
+                        break;
+                    kv_db.renew('b');
+                }
+                rc('echo', ['-e', '\r', timer/1000, 'seconds left to timeout (1/3)    ']);
+
+                assert.equal(kv_db.keys().length, 1);
+
+                timer = ms;
+                while (timer -= 1000) {
+                    rc('echo', ['-ne', '\r', timer/1000, 'seconds left to timeout (2/3)    ']);
+                    coroutine.sleep(1000);
+                }
+                rc('echo', ['-e', '\r', timer/1000, 'seconds left to timeout (2/3)    ']);
+                assert.equal(kv_db.get('b'), 'test b');
+
+                timer = 60000;
+                while (timer -= 1000) {
+                    rc('echo', ['-ne', '\r', timer/1000, 'seconds left to timeout (3/3)    ']);
+                    coroutine.sleep(1000);
+                }
+                rc('echo', ['-e', '\r', timer/1000, 'seconds left to timeout (3/3)    ']);
+                assert.equal(kv_db.get('b'), null);
+                assert.equal(kv_db.keys().length, 0);
+            });
+
+        });
+
     }
 });
 


### PR DESCRIPTION
1. Redis 使用 timeout (TTL) 选项时, table_name 需设置为空字符串 ""
2. LevelDB 和 object/Map 现不支持 keys(), 无返回结果